### PR TITLE
Use LiveIntent's liveconnect.

### DIFF
--- a/allowedModules.js
+++ b/allowedModules.js
@@ -13,7 +13,8 @@ module.exports = {
     ...sharedWhiteList,
     'criteo-direct-rsa-validate',
     'jsencrypt',
-    'crypto-js'
+    'crypto-js',
+    'live-connect'
   ],
   'src': [
     ...sharedWhiteList,

--- a/integrationExamples/gpt/liveIntentId_example.html
+++ b/integrationExamples/gpt/liveIntentId_example.html
@@ -1,0 +1,69 @@
+<!--
+  This page resolves an identifier via LiveIntent Id. It can be considered a "hello world" example for using
+  Prebid with the LiveIntent Id Module.
+  The page also has an example of integration with USP privacy policy. The consent string is attached to the
+  LiveIntent's pixel requests.
+-->
+
+<html>
+<head>
+    <script async src="../../build/dev/prebid.js"></script>
+    <script>
+      var adUnits = [{
+        code: 'div-gpt-ad-1460505748561-0',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [300, 600]],
+          }
+        },
+        // Replace this object to test a new Adapter!
+        bids: [{
+          bidder: 'appnexus',
+          params: {
+            placementId: 13144370
+          }
+        }],
+      }];
+
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+
+    </script>
+
+    <script>
+      pbjs.que.push(function() {
+        pbjs.setConfig({
+          userSync: {
+            userIds: [{
+              name: 'liveIntentId',
+              params: {
+                publisherId: '9896876',
+                identifiersToResolve: ['my-own-cookie']
+              }
+            }]
+          },
+          consentManagement: {
+            usp: {
+              cmpApi: 'static',
+              consentData: {
+                getUSPData: {
+                  uspString: '1YYY'
+                }
+              }
+            }
+          }
+        });
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({
+          bidsBackHandler: function(bidResponses) {
+            console.log(bidResponses)
+          }
+        });
+      });
+    </script>
+</head>
+
+<body>
+<h2>Prebid.js LiveIntent Id Test</h2>
+</body>
+</html>

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -32,6 +32,7 @@ function initializeLiveConnect(configParams) {
     utils.logError(`${MODULE_NAME} - publisherId must be defined, not a '${publisherId}'`);
     return;
   }
+
   const identityResolutionConfig = {
     source: 'prebid',
     publisherId: publisherId
@@ -45,13 +46,21 @@ function initializeLiveConnect(configParams) {
   if (configParams.storage && configParams.storage.expires) {
     identityResolutionConfig.expirationDays = configParams.storage.expires;
   }
-  liveConnect = LiveConnect({
+
+  const liveConnectConfig = {
     identifiersToResolve: configParams.identifiersToResolve || [],
     wrapperName: 'prebid',
-    usPrivacyString: uspDataHandler.getConsentData(),
     identityResolutionConfig: identityResolutionConfig
-  });
+  };
+  const usPrivacyString = uspDataHandler.getConsentData();
+  if (usPrivacyString) {
+    liveConnectConfig.usPrivacyString = usPrivacyString;
+  }
+  if (configParams.appId) {
+    liveConnectConfig.appId = configParams.appId;
+  }
 
+  liveConnect = LiveConnect(liveConnectConfig);
   return liveConnect;
 }
 

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -6,25 +6,25 @@
  */
 import * as utils from '../src/utils';
 import { submodule } from '../src/hook';
-import * as liveConnect from 'live-connect-js/cjs/live-connect';
+import { LiveConnect } from 'live-connect-js/cjs/live-connect';
 import { uspDataHandler } from '../src/adapterManager';
 
 const MODULE_NAME = 'liveIntentId';
 
 let eventFired = false;
-let lcClient = null;
+let liveConnect = null;
 
 /**
  * This function is used in tests
  */
 export function reset() {
   eventFired = false;
-  lcClient = null;
+  liveConnect = null;
 }
 
-function initLcClient(configParams) {
-  if (lcClient) {
-    return lcClient;
+function initializeLiveConnect(configParams) {
+  if (liveConnect) {
+    return liveConnect;
   }
 
   const publisherId = configParams && configParams.publisherId;
@@ -45,19 +45,19 @@ function initLcClient(configParams) {
   if (configParams.storage && configParams.storage.expires) {
     identityResolutionConfig.expirationDays = configParams.storage.expires;
   }
-  lcClient = liveConnect.LiveConnect({
+  liveConnect = LiveConnect({
     identifiersToResolve: configParams.identifiersToResolve || [],
     wrapperName: 'prebid',
     usPrivacyString: uspDataHandler.getConsentData(),
     identityResolutionConfig: identityResolutionConfig
   });
 
-  return lcClient;
+  return liveConnect;
 }
 
 function tryFireEvent() {
-  if (!eventFired && lcClient) {
-    lcClient.fire();
+  if (!eventFired && liveConnect) {
+    liveConnect.fire();
     eventFired = true;
   }
 }
@@ -87,7 +87,7 @@ export const liveIntentIdSubmodule = {
     }
 
     if (configParams) {
-      initLcClient(configParams);
+      initializeLiveConnect(configParams);
       tryFireEvent();
     }
 
@@ -101,12 +101,12 @@ export const liveIntentIdSubmodule = {
    * @returns {IdResponse|undefined}
    */
   getId(configParams) {
-    const lcClient = initLcClient(configParams);
-    if (!lcClient) {
+    const liveConnect = initializeLiveConnect(configParams);
+    if (!liveConnect) {
       return;
     }
     tryFireEvent();
-    return { callback: lcClient.resolve };
+    return { callback: liveConnect.resolve };
   }
 };
 

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -37,6 +37,7 @@
  * @summary decode a stored value for passing to bid requests
  * @name Submodule#decode
  * @param {Object|string} value
+ * @param {SubmoduleParams|undefined} configParams
  * @return {(Object|undefined)}
  */
 
@@ -411,7 +412,7 @@ function initSubmodules(submodules, consentData) {
 
       if (storedId) {
         // cache decoded value (this is copied to every adUnit bid)
-        submodule.idObj = submodule.submodule.decode(storedId);
+        submodule.idObj = submodule.submodule.decode(storedId, submodule.config);
       }
     } else if (submodule.config.value) {
       // cache decoded value (this is copied to every adUnit bid)
@@ -420,7 +421,7 @@ function initSubmodules(submodules, consentData) {
       const response = submodule.submodule.getId(submodule.config.params, consentData, undefined);
       if (utils.isPlainObject(response)) {
         if (typeof response.callback === 'function') { submodule.callback = response.callback; }
-        if (response.id) { submodule.idObj = submodule.submodule.decode(response.id); }
+        if (response.id) { submodule.idObj = submodule.submodule.decode(response.id, submodule.config); }
       }
     }
     carry.push(submodule);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -74,6 +74,7 @@
  * @property {(string|undefined)} pid - placement id url param value
  * @property {(string|undefined)} publisherId - the unique identifier of the publisher in question
  * @property {(array|undefined)} identifiersToResolve - the identifiers from either ls|cookie to be attached to the getId query
+ * @property {(string|undefined)} appId - the  unique identifier of the application in question
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.5",
     "jsencrypt": "^3.0.0-rc.1",
-    "just-clone": "^1.0.2"
+    "just-clone": "^1.0.2",
+    "live-connect-js": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "fun-hooks": "^0.9.5",
     "jsencrypt": "^3.0.0-rc.1",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^1.0.8"
+    "live-connect-js": "^1.0.11"
   }
 }

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -47,6 +47,7 @@ describe('LiveIntentId', function() {
     liveIntentIdSubmodule.getId({
       ...defaultConfigParams,
       ...{
+        appId: 'a-0001',
         identifiersToResolve: ['id1', 'id2'],
         url: 'https://dummy.liveintent.com',
         storage: {
@@ -58,14 +59,14 @@ describe('LiveIntentId', function() {
     expect(lcStub.calledOnce).to.be.true;
     assert.deepEqual(lcStub.getCall(0).args[0], {
       wrapperName: 'prebid',
+      appId: 'a-0001',
       identifiersToResolve: ['id1', 'id2'],
       identityResolutionConfig: {
         source: 'prebid',
         publisherId: PUBLISHER_ID,
         url: 'https://dummy.liveintent.com',
         expirationDays: 3
-      },
-      usPrivacyString: null
+      }
     });
   });
 
@@ -111,6 +112,7 @@ describe('LiveIntentId', function() {
     liveIntentIdSubmodule.decode({}, {
       ...defaultConfigParams,
       ...{
+        appId: 'a-0001',
         identifiersToResolve: ['id1', 'id2'],
         url: 'https://dummy.liveintent.com',
         storage: {
@@ -122,14 +124,14 @@ describe('LiveIntentId', function() {
     expect(lcStub.calledOnce).to.be.true;
     assert.deepEqual(lcStub.getCall(0).args[0], {
       wrapperName: 'prebid',
+      appId: 'a-0001',
       identifiersToResolve: ['id1', 'id2'],
       identityResolutionConfig: {
         source: 'prebid',
         publisherId: PUBLISHER_ID,
         url: 'https://dummy.liveintent.com',
         expirationDays: 3
-      },
-      usPrivacyString: null
+      }
     });
   });
 


### PR DESCRIPTION
This PR introduces the following changes:
1) a dependency is added to use [live-connect](https://github.com/liveintent-berlin/live-connect) - an npm module for interaction with LiveIntent's systems
2) id resolution is rewritten to use this npm module
3) a pixel call per id resolution is added to the LiveIntent Id module. This is needed to build models on server-side for id resolution. Currently, LiveIntent's id resolution only works on the pages that contain LiveConnect's js tag on these pages as well as Prebid. The change in this pr allows using Prebid only
4) the `decode` method receives submodule-config in all cases except resolution callback

The [live-connect npm module](https://github.com/liveintent-berlin/live-connect) is open source and uses the same license as Prebid: Apache License 2.0.
The usage of external npm dependency has some benefits:
- for LiveIntent it is easier to maintain the compatibility among js and server-side code bases. The code is reusable among Prebid, LiveIntent's js tag, other proprietary header bidding solutions
- for Prebid it brings the benefit of having a code that is tested not only by unit/BrowserStack tests but also runs in real-world websites via LiveIntent's js tag